### PR TITLE
Refactor plugin config for lolcommits 0.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ cache: bundler
 rvm:
  - 2.0.0
  - 2.1.10
- - 2.2.8
- - 2.3.5
- - 2.4.2
+ - 2.2.9
+ - 2.3.6
+ - 2.4.3
+ - 2.5.0
  - ruby-head
 
 before_install:
- - gem install bundler -v 1.13.7
+ - gem update --system
  - git --version
  - git config --global user.email "lol@commits.org"
  - git config --global user.name "Lolcommits"

--- a/lib/lolcommits/hipchat/version.rb
+++ b/lib/lolcommits/hipchat/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module Hipchat
-    VERSION = "0.0.5".freeze
+    VERSION = "0.0.6".freeze
   end
 end

--- a/lib/lolcommits/plugin/hipchat.rb
+++ b/lib/lolcommits/plugin/hipchat.rb
@@ -1,18 +1,10 @@
 require 'mime/types'
+require 'net/http'
 require 'lolcommits/plugin/base'
 
 module Lolcommits
   module Plugin
     class Hipchat < Base
-
-      ##
-      # Returns the name of this plugin.
-      #
-      # @return [String] the plugin name
-      #
-      def self.name
-        'hipchat'
-      end
 
       ##
       # Returns position(s) of when this plugin should run during the capture
@@ -25,19 +17,6 @@ module Lolcommits
       end
 
       ##
-      # Returns true if the plugin has been configured. An API token, team name
-      # and HipChat room id (or name) are required.
-      #
-      # @return [Boolean] true/false indicating if plugin is configured
-      #
-      def configured?
-        super &&
-          !!(configuration['api_token'] &&
-             configuration['api_team'] &&
-             configuration['api_room'])
-      end
-
-      ##
       # Returns true/false indicating if the plugin has been correctly
       # configured. To post a message to HipChat all plugin options must be
       # set.
@@ -46,7 +25,7 @@ module Lolcommits
       # configured
       #
       def valid_configuration?
-        %w(api_token api_team api_room).all? do |option|
+        [:api_token, :api_team, :api_room].all? do |option|
           !configuration[option].to_s.strip.empty?
         end
       end
@@ -60,7 +39,7 @@ module Lolcommits
       #
       def configure_options!
         options = super
-        options.merge!(configure_auth_options) if options['enabled']
+        options.merge!(configure_auth_options) if options[:enabled]
         options
       end
 
@@ -75,7 +54,7 @@ module Lolcommits
       # @return [Boolean] indicating if HipChat post was successful
       #
       def run_capture_ready
-        print "Posting to HipChat (#{configuration['api_room']}) ..."
+        print "Posting to HipChat (#{configuration[:api_room]}) ..."
         debug "Posting to HipChat: HTTP POST to #{api_url}"
 
         boundary = "0123456789ABLEWASIEREISAWELBA9876543210"
@@ -107,14 +86,14 @@ module Lolcommits
 
       def configure_auth_options
         puts "\n"
-        puts '-' * 50
+        puts '-' * 41
         puts ' Lolcommits HipChat Plugin Configuration'
-        puts '-' * 50
+        puts '-' * 41
 
         puts "\n1. What is your Team Name (e.g. teamname.hipchat.com)"
         print "> "
-        teamname = parse_user_input(gets.strip)
-        puts "\n2. We need a HipChat token (visit https://#{teamname}.hipchat.com/account/api)"
+        team = parse_user_input(gets.strip)
+        puts "\n2. We need a HipChat token (visit https://#{team}.hipchat.com/account/api)"
         puts "(ensure the scope 'Send Message' is selected)"
         print "> "
         token = parse_user_input(gets.strip)
@@ -123,9 +102,9 @@ module Lolcommits
         room = parse_user_input(gets.strip)
 
         {
-          'api_team'  => teamname,
-          'api_token' => token,
-          'api_room'  => room
+          api_team: team,
+          api_token: token,
+          api_room: room
         }
       end
 
@@ -156,7 +135,7 @@ module Lolcommits
       end
 
       def api_url
-        URI("http://#{configuration['api_team']}.hipchat.com/v2/room/#{configuration['api_room']}/share/file?auth_token=#{configuration['api_token']}")
+        URI("http://#{configuration[:api_team]}.hipchat.com/v2/room/#{configuration[:api_room]}/share/file?auth_token=#{configuration[:api_token]}")
       end
 
       def message

--- a/lolcommits-hipchat.gemspec
+++ b/lolcommits-hipchat.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.0.0"
   spec.add_runtime_dependency "mime-types"
 
-  spec.add_development_dependency "lolcommits", ">= 0.9.5"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
* require at least lolcommits >= 0.10.0
* drop`self.name` method (plugins are now identified by their gem name)
* drop calls to `configured?` (no longer available or useful)
* symbolize all plugin config keys
* update rubies for Travis CI
* bump gem version for new plugin release